### PR TITLE
Updates query by geostore to return value

### DIFF
--- a/app/src/services/cartoDBService.js
+++ b/app/src/services/cartoDBService.js
@@ -8,7 +8,7 @@ const NotFound = require('errors/notFound');
 const GeostoreService = require('services/geostoreService');
 
 const WORLD = `WITH poly AS (SELECT * FROM ST_Transform(ST_SimplifyPreserveTopology(ST_SetSRID(ST_MakeValid(ST_GeomFromGeoJSON('{{{geojson}}}')), 4326), 0.01), 3857) geojson)
-             SELECT data_type
+             SELECT data_type, count(*) AS value
              FROM imazon_sad i, poly        WHERE i.date >= '{{begin}}'::date
                AND i.date <= '{{end}}'::date  and st_intersects(poly.geojson, i.the_geom_webmercator) group by data_type `;
 


### PR DESCRIPTION
The query by geostore currently does not return the number of deforestation alerts, updates the sql to do so.


Should return:

``` value: [
             {
                 data_type: defor,
                 value: 90
              }, ... 
          ]
```

Requires DEV/PROD testing.